### PR TITLE
Omit slack channel id from CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ workflows:
             branches:
               only: master
       - slack/approval-notification:
-          channel: CT64KG0MA
+          channel: ${SLACK_CHANNEL}
           context: release-timetree-sdk
           requires:
             - test


### PR DESCRIPTION
Replace channel id to environment variable from hard code.
This value is not a secret value, so git log is not rewritten.