### PR TITLE
chore(deps): update renovate settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
-  "extends": [
-    "config:base"
-  ]
+  "extends": ["config:base", "group:definitelyTyped"],
+  "prHourlyLimit": 12,
+  "postUpdateOptions": ["yarnDedupeHighest"],
+  "lockFileMaintenance": true
 }


### PR DESCRIPTION
Updated the renovate settings.

- Grouping settings
- Limit the number of PRs per hour
- Automatic execution of yarn-deduplicate
- Automated update of lock file