### PR TITLE
fix: rename amazon:XXX tag

### DIFF
--- a/src/__tests__/renderToString.spec.tsx
+++ b/src/__tests__/renderToString.spec.tsx
@@ -36,6 +36,17 @@ describe("renderToString", () => {
     expect(`${jsx}`).toBe(`<say-as interpret-as="date">foo</say-as>`);
   });
 
+  test("should convert amazon tag", () => {
+    const AmazonComponents = () => (
+      <speak>
+      <amazon-effect name="whispered">effect</amazon-effect>
+      <amazon-emotion name="excited" intensity="low">emotion</amazon-emotion>
+      <amazon-domain name="news">domain</amazon-domain>
+      </speak>
+    )
+    expect(renderToString(<AmazonComponents />)).toBe(`<speak><amazon:effect name=\"whispered\">effect</amazon:effect><amazon:emotion name=\"excited\" intensity=\"low\">emotion</amazon:emotion><amazon:domain name=\"news\">domain</amazon:domain></speak>`)
+  })
+
   test("should match empty string with null component", () => {
     const NullComponent: FC = () => null;
     expect(renderToString(<NullComponent />)).toBe("");

--- a/src/__tests__/renderToString.spec.tsx
+++ b/src/__tests__/renderToString.spec.tsx
@@ -37,15 +37,19 @@ describe("renderToString", () => {
   });
 
   test("should convert amazon tag", () => {
-    const AmazonComponents = () => (
+    const AmazonComponents: FC = () => (
       <speak>
-      <amazon-effect name="whispered">effect</amazon-effect>
-      <amazon-emotion name="excited" intensity="low">emotion</amazon-emotion>
-      <amazon-domain name="news">domain</amazon-domain>
+        <amazon-effect name="whispered">effect</amazon-effect>
+        <amazon-emotion name="excited" intensity="low">
+          emotion
+        </amazon-emotion>
+        <amazon-domain name="news">domain</amazon-domain>
       </speak>
-    )
-    expect(renderToString(<AmazonComponents />)).toBe(`<speak><amazon:effect name=\"whispered\">effect</amazon:effect><amazon:emotion name=\"excited\" intensity=\"low\">emotion</amazon:emotion><amazon:domain name=\"news\">domain</amazon:domain></speak>`)
-  })
+    );
+    expect(renderToString(<AmazonComponents />)).toBe(
+      `<speak><amazon:effect name="whispered">effect</amazon:effect><amazon:emotion name="excited" intensity="low">emotion</amazon:emotion><amazon:domain name="news">domain</amazon:domain></speak>`
+    );
+  });
 
   test("should match empty string with null component", () => {
     const NullComponent: FC = () => null;

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -12,15 +12,15 @@ declare global {
     type IntrinsicElements = {
       // https://developer.amazon.com/ja-JP/docs/alexa/custom-skills/speech-synthesis-markup-language-ssml-reference.html
 
-      "amazon:domain": ElementWithChildren<{
+      "amazon-domain": ElementWithChildren<{
         name: "music" | "news";
       }>;
 
-      "amazon:effect": ElementWithChildren<{
+      "amazon-effect": ElementWithChildren<{
         name: "whispered";
       }>;
 
-      "amazon:emotion": ElementWithChildren<{
+      "amazon-emotion": ElementWithChildren<{
         name: "excited" | "disappointed";
         intensity: "low" | "medium" | "high";
       }>;

--- a/src/renderToString.ts
+++ b/src/renderToString.ts
@@ -29,6 +29,12 @@ const toAttr = <P>(props: Element<P>["props"]): string =>
         .map(([name, value]) => `${name}="${value}"`)
         .join(" ")
     : "";
+const convertElementType = (type: string): string => {
+  if (/^amazon/.test(type)) {
+    return type.split('-').join(':')
+  }
+  return type
+}
 
 const render = (element: Children | Children[] | null): string => {
   if (!element) return "";
@@ -43,9 +49,10 @@ const render = (element: Children | Children[] | null): string => {
       return render(element.type(element.props));
     }
     const attr = toAttr(element.props);
+    const type = convertElementType(element.type)
     return children
-      ? `<${element.type}${attr}>${children}</${element.type}>`
-      : `<${element.type}${attr}/>`;
+      ? `<${type}${attr}>${children}</${type}>`
+      : `<${type}${attr}/>`;
   }
 
   return escape(element);

--- a/src/renderToString.ts
+++ b/src/renderToString.ts
@@ -31,10 +31,10 @@ const toAttr = <P>(props: Element<P>["props"]): string =>
     : "";
 const convertElementType = (type: string): string => {
   if (/^amazon/.test(type)) {
-    return type.split('-').join(':')
+    return type.split("-").join(":");
   }
-  return type
-}
+  return type;
+};
 
 const render = (element: Children | Children[] | null): string => {
   if (!element) return "";
@@ -49,7 +49,7 @@ const render = (element: Children | Children[] | null): string => {
       return render(element.type(element.props));
     }
     const attr = toAttr(element.props);
-    const type = convertElementType(element.type)
+    const type = convertElementType(element.type);
     return children
       ? `<${type}${attr}>${children}</${type}>`
       : `<${type}${attr}/>`;


### PR DESCRIPTION
Patch code for the issue #40 

## Not work

```tsx
<speak>
      <amazon:effect name="whispered">effect</amazon:effect>
      <amazon:emotion name="excited" intensity="low">emotion</amazon:emotion>
      <amazon:domain name="news">domain</amazon:domain>
      </speak>
```

## Work

```tsx
<speak>
      <amazon-effect name="whispered">effect</amazon-effect>
      <amazon-emotion name="excited" intensity="low">emotion</amazon-emotion>
      <amazon-domain name="news">domain</amazon-domain>
      </speak>
```

## Then
We write own tsx element as `amazon-XXX`, and the `renderToString` function will replace `-` to `:`.
So we can use these element in our tsx project, and the ssml will works well!