### PR TITLE
docs(readme): put lists of supported tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,25 @@ const Foo: FC<{ name: string }> = ({ name }) => (
 console.log(renderToString(<Foo name="bar" />));
 ```
 
+## Supported tags
+
+- `<amazon-domain />` (amazon:domain)
+- `<amazon-effect />` (amazon:effect)
+- `<amazon-emotion />` (amazon:emotion)
+- `<audio />`
+- `<break />`
+- `<emphasis />`
+- `<lang />`
+- `<p />`
+- `<phoneme />`
+- `<prosody />`
+- `<s />`
+- `<say-as />`
+- `<speak />`
+- `<sub />`
+- `<voice />`
+- `<w />`
+
 ## Using with eslint
 
 Use [`eslint-pllugin-react`](https://github.com/yannickcr/eslint-plugin-react) to make lint work correctly.


### PR DESCRIPTION
Put lists of tag into the README.md.
We can easy to understand what tag can we use.

(JUST IDEA.if you feel unnecessary, please close it.)