### PR TITLE
chore(renovate): grouping node version updates for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,10 @@
 {
   "extends": ["config:js-lib", "group:definitelyTyped", ":maintainLockFilesWeekly"],
-  "postUpdateOptions": ["yarnDedupeHighest"]
+  "postUpdateOptions": ["yarnDedupeHighest"],
+  "packageRules": [
+    {
+      "groupName": "nodejs",
+      "packageNames": ["circleci/node", "node"]
+    }
+  ]
 }


### PR DESCRIPTION
If there is a new version upgrade for node, renovate may create multiple PRs. (#58, #61)
So I changed the setting of renovate so that it can be grouped.